### PR TITLE
Avoid running CI tests which call the InvenioRDM API if required repo secrets are not set

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: Test with mypy and pytest
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -16,33 +16,45 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.12"]
+    env:
+      ZENODO_SANDBOX_API_KEY: ${{secrets.ZENODO_SANDBOX_API_KEY}}
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install poetry
-      run: |
-        python -m pip install poetry
-    - name: Install dependencies
-      run: |
-        poetry install
-    - name: Set up credentials
-      run: |
-        echo "INVENIORDM_BASE_URL=\"https://sandbox.zenodo.org/\"" >> .env
-        echo "INVENIORDM_API_KEY=\"$ZENODO_SANDBOX_API_KEY\"" >> .env
-      shell: bash
-      env:
-        ZENODO_SANDBOX_API_KEY : ${{secrets.ZENODO_SANDBOX_API_KEY}}
-    - name: Lint with mypy
-      run: |
-        poetry run mypy . --ignore-missing-imports
-    - name: Test with pytest
-      run: |
-        poetry run pytest
-    - uses: actions/upload-artifact@v4
-      with:
-        name: test-outputs-${{ matrix.os }}-python${{ matrix.python-version }}
-        path: test/output/
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: |
+          python -m pip install poetry
+      - name: Install dependencies
+        run: |
+          poetry install
+      - name: Set up credentials
+        run: |
+          echo "INVENIORDM_BASE_URL=\"https://sandbox.zenodo.org/\"" >> .env
+          echo "INVENIORDM_API_KEY=\"$ZENODO_SANDBOX_API_KEY\"" >> .env
+        shell: bash
+      - name: Lint with mypy
+        run: |
+          poetry run mypy . --ignore-missing-imports
+      # tests with pytest are split into two steps:
+      # tests that do not require InvenioRDM API credentials are always run,
+      # but tests that require credentials are only run if the relevant secret is set.
+      # Contributors only need to set the secret if they are modifying the code that
+      # interacts with the InvenioRDM API
+      - name: Test with pytest (except uploads)
+        run: |
+          poetry run pytest -k "not needs_credentials"
+      - name: Test with pytest (uploads only)
+        run: |
+          poetry run pytest -k "needs_credentials"
+        if: ${{ ZENODO_SANDBOX_API_KEY != '' }}
+      # output ro-crate-metadata.json files and log files are saved as these are useful for debugging
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-output-${{ matrix.os }}-python${{ matrix.python-version }}
+          path: test/output/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-        matrix:
-            os: [ubuntu-latest, macos-latest]
-            python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ The result of uploading the [`/test/test-ro-crate`](./test/test-ro-crate/) direc
 We tested the tool on a real-world RO-Crate ([https://reliance.rohub.org/b927e3d8-5bfd-4332-b14c-ab3a07d36dc6?activetab=overview](https://reliance.rohub.org/b927e3d8-5bfd-4332-b14c-ab3a07d36dc6?activetab=overview)). The result is shown below:
 
 ![](./images/real-world-example.png)
+
+## For Developers
+
+See the [developer guide](docs/developer_guide.md) for information on project structure and how to contribute. Pull requests and issues from new contributors are welcome!

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -35,9 +35,14 @@ poetry shell
 
 ## Run tests
 
-Beware that tests can make Zenodo uploads using your access token.
+Some tests can make Zenodo uploads using your access token. The [environment variables](#set-up-the-environmental-variables) must be configured in order for those tests to succeed. But you can also choose to run the test suite without them.
 
-In the root directory:
+To run all tests **except** the ones which make uploads:
+```bash
+pytest -k "not needs_credentials"
+```
+
+To run all tests **including** the ones which make uploads:
 ```bash
 pytest
 ```

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -62,6 +62,7 @@ def test_created_datacite_files(crate_name):
         assert output_json == expected_json
 
 
+@pytest.mark.needs_credentials
 @pytest.mark.parametrize("crate_name", [*CRATES])
 def test_created_invenio_records(crate_name):
     # Arrange
@@ -123,6 +124,7 @@ def test_created_invenio_records(crate_name):
     assert record["submitted"] is False
 
 
+@pytest.mark.needs_credentials
 def test_cli__zip():
     """Test uploading RO-Crate as a single zip file."""
     # Arrange
@@ -156,6 +158,7 @@ def test_cli__zip():
     assert result_zip["checksum"] == local_checksum
 
 
+@pytest.mark.needs_credentials
 def test_cli__datacite():
     """Test creating a record from a pre-existing DataCite file."""
     # Arrange
@@ -191,6 +194,7 @@ def test_cli__datacite():
     assert record["submitted"] is False
 
 
+@pytest.mark.needs_credentials
 def test_cli__omit_roc_files():
     """Test creating a record with omit_roc_files option."""
     # Arrange
@@ -220,6 +224,7 @@ def test_cli__omit_roc_files():
         assert "ro-crate-preview" not in str(local_path.relative_to(crate_path))
 
 
+@pytest.mark.needs_credentials
 def test_cli__publish():
     """Test creating a record with publish option."""
     # Arrange

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from requests.exceptions import HTTPError
+from unittest import mock
 
 from rocrate_inveniordm.deposit import deposit
 import rocrate_inveniordm.upload.credentials as credentials
@@ -76,6 +77,7 @@ def test_get_mapping_class():
     assert out == expected
 
 
+@mock.patch.dict(os.environ, {"INVENIORDM_API_KEY": "example-for-testing"})
 def test_get_request_headers():
     expected_headers = {
         "Accept": "application/json",
@@ -88,6 +90,7 @@ def test_get_request_headers():
     assert headers == expected_headers
 
 
+@pytest.mark.needs_credentials
 def test_fetch_inveniordm_record__exists():
     """Test fetching a created record."""
     # Arrange
@@ -102,6 +105,7 @@ def test_fetch_inveniordm_record__exists():
     assert "metadata" in record
 
 
+@pytest.mark.needs_credentials
 def test_fetch_inveniordm_record__nonexistent():
     """Test that fetching a nonexistent record raises an error."""
     # Arrange


### PR DESCRIPTION
This will make it easier for contributors to submit PRs and run tests - they do not need to set up the secret in their fork/dev environment unless they are editing the parts of the code that interact with the InvenioRDM API.